### PR TITLE
Rearrange

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - run: make
+      - run: go run cmd/templates/main.go
       - run: make development
         if: github.repository == 'lukemassa/jclubtakeaways-gui-dev'
       - name: Setup Pages

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,2 @@
-html:
-	@go run main.go
-
 development:
 	git rev-parse HEAD > $(CURDIR)/docs/commit.txt

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Production
 
-This repo is located in https://github.com/lukemassa/jclubtakeaways-gui. A github action builds the page into docs/, uploads as an artifact and deploys to github pages (https://github.com/lukemassa/jclubtakeaways-gui/settings/pages).
+This repo is located in https://github.com/lukemassa/jclubtakeaways. A github action builds the page into docs/, uploads as an artifact and deploys to github pages (https://github.com/lukemassa/jclubtakeaways/settings/pages).
 
 The page is then visible at https://jclubtakeaways.com
 
@@ -20,7 +20,7 @@ High level, submit PRs/merge directly to "development" to develop, then merge de
 
 ### Propose a change
 
-1. Go to the development branch in git (https://github.com/lukemassa/jclubtakeaways-gui/tree/development)
+1. Go to the development branch in git (https://github.com/lukemassa/jclubtakeaways/tree/development)
 2. Create a PR with target branch "development"
 3. Have Luke review and merge
 4. Visit https://development.d7s2t12hepi6g.amplifyapp.com to view change (should be live in a few minutes)

--- a/TODO
+++ b/TODO
@@ -3,6 +3,7 @@
    - Not sure which one currently deploys to heroku, but let's make that deploy to Amazon instead, better understood
    - -web is unnecessary, bring that back home here
    - -api no idea what's up there
+- Move the token generation into 
 - Figure out what's on AWS
 - Get rid of heroku from the process, make that API on AWS
 - More fully separate the API from the UI

--- a/cmd/templates/main.go
+++ b/cmd/templates/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/lukemassa/jclubtakeaways/internal/templater"
+)
+
+func main() {
+
+	t := templater.New("src/templates")
+	if len(os.Args) > 1 {
+		if os.Args[1] == "--server" {
+			http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, "/index.html", http.StatusMovedPermanently)
+			})
+			http.Handle("/{page}", t)
+			log.Print("Listening on :8080")
+			log.Fatal(http.ListenAndServe(":8080", nil))
+		}
+		log.Fatal("Usage: [--server]")
+	}
+	err := t.Write("docs")
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/lukemassa/jclubtakeaways-gui
+module github.com/lukemassa/jclubtakeaways
 
 go 1.23

--- a/internal/templater/main.go
+++ b/internal/templater/main.go
@@ -1,4 +1,4 @@
-package main
+package templater
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ type Templater struct {
 	srcDir string
 }
 
-func NewTemplater(srcDir string) Templater {
+func New(srcDir string) Templater {
 	return Templater{
 		srcDir: srcDir,
 	}
@@ -80,6 +80,7 @@ func (t Templater) Write(dir string) error {
 
 	return nil
 }
+
 func (t Templater) getTemplateFromURL(url string) (*template.Template, error) {
 
 	if !strings.HasSuffix(url, ".html") {
@@ -116,25 +117,5 @@ func (t Templater) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err = tmpl.Execute(w, nil)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
-	}
-}
-
-func main() {
-
-	t := NewTemplater("src/templates")
-	if len(os.Args) > 1 {
-		if os.Args[1] == "--server" {
-			http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-				http.Redirect(w, r, "/index.html", http.StatusMovedPermanently)
-			})
-			http.Handle("/{page}", t)
-			log.Print("Listening on :8080")
-			log.Fatal(http.ListenAndServe(":8080", nil))
-		}
-		log.Fatal("Usage: [--server]")
-	}
-	err := t.Write("docs")
-	if err != nil {
-		log.Fatal(err)
 	}
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-PyJWT
-requests
-cryptography

--- a/src/templates/about.html
+++ b/src/templates/about.html
@@ -27,8 +27,8 @@
         <li>1830s utopian sex cults
         <li>climate refugees
         <li>sock engineering
-        <li>preventing injury in rock climbing
         <li>the history of the Sicilan mafia
+        <li>preventing injury in rock climbing
         <li>constitutional monarchies
         <li>rare earth metals 
         <li>the Toledo war


### PR DESCRIPTION
## What

- Rearranged go code into cmd and internal
- Fix references from jclubtakeaways-gui
- Remove python stuff
- Remove some of the make dependency
- Do a reorder in the file

## Why

- Better layout for go
- This repo was renamed
- No more python stuff
- No need for make if we can just run command manually
- Made a reorder so I can confirm everything worked